### PR TITLE
Prevent param duplication when building with Gradle

### DIFF
--- a/aapt-wrapper.cpp
+++ b/aapt-wrapper.cpp
@@ -22,6 +22,7 @@ using namespace std;
 static const string VERSION = "1.0";
 static const string DATE    = "31 Dec 2017";
 static const string PROJECT = "https://github.com/dandar3/android-aapt-wrapper";
+static const string NO_VERSION_VECTOR_PARAM = " --no-version-vectors";
 
 #if defined(WIN32)
 static const char   PATH_SEPARATOR = '\\';
@@ -56,17 +57,17 @@ int main(int argc, char *argv[]) {
     // No need to quote...
     else {
       cmdline.append(" ");
-      cmdline.append(argv[i]);    
+      cmdline.append(argv[i]);
     }
   }
   
   // 'package' action...
-  if (argc > 1 && strcmp(argv[1], "package") == 0) {
-    cmdline.append(" --no-version-vectors");
+  if (argc > 1 && strcmp(argv[1], "package") == 0 && cmdline.find(NO_VERSION_VECTOR_PARAM) == string::npos) {
+    cmdline.append(NO_VERSION_VECTOR_PARAM);
   }
   
   // Print new command line...
-  cout << "Android Asset Packaging Tool - Wrapper" << endl;
+  cout << endl << "Android Asset Packaging Tool - Wrapper" << endl;
   cout << "Version "   << VERSION << " (" << DATE << ")" << endl;
   cout << PROJECT      << endl    << endl;
   cout << "Command: "  << endl;


### PR DESCRIPTION
- added condition to include the --no-version-vectors param only if it's not already there
- created a constant for the param
- added additional newline for clearer output

One problem I have building your code on Windows (before my changes) is that when I launch the project build with Gradle it doesn't include full paths to some files/folders (like `AndroidManifest.xml` and `symbols\debug`).

Example of build command with the executable from your release (with successful build).

    E:\tools\android-sdk\build-tools\android-7.1.1\aapt-original.exe package -f --no-crunch 
    -I E:\tools\android-sdk\platforms\android-8.0.0\android.jar 
    -M \\?\E:\Documents\android\TestApp\app\build\intermediates\manifests\full\debug\AndroidManifest.xml 
    -S E:\Documents\android\TestApp\app\build\intermediates\res\merged\debug -m 
    -J \\?\E:\Documents\android\TestApp\app\build\generated\source\r\debug 
    -F E:\Documents\android\TestApp\app\build\intermediates\res\resources-debug.ap_ --debug-mode 
    --custom-package org.home.testapp -0 apk 
    --output-text-symbols \\?\E:\Documents\android\TestApp\app\build\intermediates\symbols\debug 
    --no-version-vectors --no-version-vectors

And the same command with the executable built with MinGW 4.8.2.

    E:\tools\android-sdk\build-tools\android-7.1.1\aapt-original.exe package -f --no-crunch 
    -I E:\tools\android-sdk\platforms\android-8.0.0\android.jar 
    -M \\AndroidManifest.xml 
    -S E:\Documents\android\TestApp\app\build\intermediates\res\merged\debug -m 
    -J \\debug 
    -F E:\Documents\android\TestApp\app\build\intermediates\res\resources-debug.ap_ --debug-mode 
    --custom-package org.home.testapp -0 apk 
    --output-text-symbols \\debug 
    --no-version-vectors

As can be seen the `-M`, -`J` and `--output-text-symbols` have path problems. I guess because of the long-path formats `\\?\` in Windows.

Do you know any fix for that? What version of MinGW did you use for the `.exe` build?

Thanks.
